### PR TITLE
Update Lombok version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.26</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
With the old Lombok version we got this error when building on our CI:
```
    Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:testCompile (java-test-compile) on project nimble-clinic-backend: Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x28fa86a7) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x28fa86a7 -> [Help 1]
```

Upgrading fixed it